### PR TITLE
added manifest tool

### DIFF
--- a/vars/dfRelease.groovy
+++ b/vars/dfRelease.groovy
@@ -4,15 +4,5 @@ def call(String project, gox = false) {
     sh "docker image push vfarcic/${project}:${currentBuild.displayName}"
     sh "docker image push vfarcic/${project}-docs:latest"
     sh "docker image push vfarcic/${project}-docs:${currentBuild.displayName}"
-    
-    sh """bash -c "
-        curl -L -o manifest-tool https://github.com/estesp/manifest-tool/releases/download/v0.7.0/manifest-tool-linux-amd64
-        chmod +x manifest-tool"
-    """
-    
-    sh """./manifest-tool push from-args --platforms linux/arm --template "vfarcic/${project}:${currentBuild.displayName}-OS-ARCH" --target "vfarcic/${project}:${currentBuild.displayName}""""
-    sh """./manifest-tool push from-args --platforms linux/arm --template "vfarcic/${project}:${currentBuild.displayName}-OS-ARCH" --target "vfarcic/${project}:latest""""
-    sh """./manifest-tool push from-args --platforms linux/arm --template "vfarcic/${project}:${currentBuild.displayName}-OS-ARCH" --target "vfarcic/${project}-docs:${currentBuild.displayName}""""
-    sh """./manifest-tool push from-args --platforms linux/arm --template "vfarcic/${project}:${currentBuild.displayName}-OS-ARCH" --target "vfarcic/${project}-docs:latest""""
     dockerLogout()
 }

--- a/vars/dfRelease.groovy
+++ b/vars/dfRelease.groovy
@@ -4,5 +4,15 @@ def call(String project, gox = false) {
     sh "docker image push vfarcic/${project}:${currentBuild.displayName}"
     sh "docker image push vfarcic/${project}-docs:latest"
     sh "docker image push vfarcic/${project}-docs:${currentBuild.displayName}"
+    
+    sh """bash -c "
+        curl -L -o manifest-tool https://github.com/estesp/manifest-tool/releases/download/v0.7.0/manifest-tool-linux-amd64
+        chmod +x manifest-tool"
+    """
+    
+    sh """./manifest-tool push from-args --platforms linux/arm --template "vfarcic/${project}:${currentBuild.displayName}-OS-ARCH" --target "vfarcic/${project}:${currentBuild.displayName}""""
+    sh """./manifest-tool push from-args --platforms linux/arm --template "vfarcic/${project}:${currentBuild.displayName}-OS-ARCH" --target "vfarcic/${project}:latest""""
+    sh """./manifest-tool push from-args --platforms linux/arm --template "vfarcic/${project}:${currentBuild.displayName}-OS-ARCH" --target "vfarcic/${project}-docs:${currentBuild.displayName}""""
+    sh """./manifest-tool push from-args --platforms linux/arm --template "vfarcic/${project}:${currentBuild.displayName}-OS-ARCH" --target "vfarcic/${project}-docs:latest""""
     dockerLogout()
 }

--- a/vars/dfReleaseArm.groovy
+++ b/vars/dfReleaseArm.groovy
@@ -17,7 +17,7 @@ def call(String project) {
         chmod +x manifest-tool"
     """
     
-    sh """./manifest-tool push from-args --platforms linux/arm --template "vfarcic/${project}:${TRAVIS_TAG}-OS-ARCH" --target "vfarcic/${project}:${currentBuild.displayName}-arm""""
-    sh """./manifest-tool push from-args --platforms linux/arm --template "vfarcic/${project}:${TRAVIS_TAG}-OS-ARCH" --target "vfarcic/${project}:latest-arm""""
+    sh """./manifest-tool push from-args --platforms linux/arm --template "vfarcic/${project}:${currentBuild.displayName}-OS-ARCH" --target "vfarcic/${project}:${currentBuild.displayName}-arm""""
+    sh """./manifest-tool push from-args --platforms linux/arm --template "vfarcic/${project}:${currentBuild.displayName}-OS-ARCH" --target "vfarcic/${project}:latest-arm""""
     dockerLogout()
 }

--- a/vars/dfReleaseArm.groovy
+++ b/vars/dfReleaseArm.groovy
@@ -11,5 +11,13 @@ def call(String project) {
     sh "docker image push vfarcic/${project}:${currentBuild.displayName}-arm"
     sh "docker image tag vfarcic/${project}:${currentBuild.displayName}-arm vfarcic/${project}:latest-arm"
     sh "docker image push vfarcic/${project}:latest-arm"
+    
+    sh """bash -c "
+        curl -L -o manifest-tool https://github.com/estesp/manifest-tool/releases/download/v0.7.0/manifest-tool-linux-amd64
+        chmod +x manifest-tool"
+    """
+    
+    sh """./manifest-tool push from-args --platforms linux/arm --template "vfarcic/${project}:${TRAVIS_TAG}-OS-ARCH" --target "vfarcic/${project}:${currentBuild.displayName}-arm""""
+    sh """./manifest-tool push from-args --platforms linux/arm --template "vfarcic/${project}:${TRAVIS_TAG}-OS-ARCH" --target "vfarcic/${project}:latest-arm""""
     dockerLogout()
 }


### PR DESCRIPTION
Added manifest tool in dfReleaseArm.groovy for arm images.

When it works (not yet tested), I suggest do the same for the amd64 architecture. For this to work some small modifications are needed in the dfBuild.groovy file.

```
docker tag vfarcic/${project} vfarcic/${project}:${currentBuild.displayName}-linux-amd64
```

Instead of : 
```
docker tag vfarcic/${project} vfarcic/${project}:${currentBuild.displayName}
```

But first lets see if the arm image works :)