### PR TITLE
fix: docker-flow/docker-flow-proxy#18

### DIFF
--- a/vars/dfRelease2.groovy
+++ b/vars/dfRelease2.groovy
@@ -17,26 +17,6 @@ def call(String project, gox = false) {
     // Push image for docs
     sh "docker image push dockerflow/${project}-docs:${currentBuild.displayName}"
   
-
-    // Manifest Create ${project}:${currentBuild.displayName}-linux-amd64
-    sh """docker manifest create dockerflow/${project}:${currentBuild.displayName}-linux-amd64 \
-        dockerflow/${project}:${currentBuild.displayName}-linux-amd64"""
-  
-    // Manifest Push ${project}:${currentBuild.displayName}-linux-amd64
-    sh "docker manifest push dockerflow/${project}:${currentBuild.displayName}-linux-amd64"
-  
-  
-    // Manifest Create and Push dockerflow/${project}:${currentBuild.displayName}-linux-arm
-    sh """docker manifest create dockerflow/${project}:${currentBuild.displayName}-linux-arm \
-        dockerflow/${project}:${currentBuild.displayName}-linux-arm"""
-    
-    // Manifest Annotate dockerflow/${project}:${currentBuild.displayName}-linux-arm
-    sh "docker manifest annotate dockerflow/${project}:${currentBuild.displayName}-linux-arm dockerflow/${project}:${currentBuild.displayName}-linux-arm --os=linux --arch=arm --variant=v7"
-  
-    // Manifest push dockerflow/${project}:${currentBuild.displayName}-linux-arm
-    sh "docker manifest push dockerflow/${project}:${currentBuild.displayName}-linux-arm"
-  
-  
     // Manifest Create dockerflow/${project}:${currentBuild.displayName}
     sh """docker manifest create dockerflow/${project}:${currentBuild.displayName} \
         dockerflow/${project}:${currentBuild.displayName}-linux-amd64 \
@@ -60,5 +40,24 @@ def call(String project, gox = false) {
     // Manifest Push dockerflow/${project}:latest
     sh "docker manifest push dockerflow/${project}:latest"
 
+  
+    // Manifest Create ${project}:${currentBuild.displayName}-linux-amd64
+    sh """docker manifest create dockerflow/${project}:${currentBuild.displayName}-linux-amd64 \
+        dockerflow/${project}:${currentBuild.displayName}-linux-amd64"""
+  
+    // Manifest Push ${project}:${currentBuild.displayName}-linux-amd64
+    sh "docker manifest push dockerflow/${project}:${currentBuild.displayName}-linux-amd64"
+  
+  
+    // Manifest Create and Push dockerflow/${project}:${currentBuild.displayName}-linux-arm
+    sh """docker manifest create dockerflow/${project}:${currentBuild.displayName}-linux-arm \
+        dockerflow/${project}:${currentBuild.displayName}-linux-arm"""
+    
+    // Manifest Annotate dockerflow/${project}:${currentBuild.displayName}-linux-arm
+    sh "docker manifest annotate dockerflow/${project}:${currentBuild.displayName}-linux-arm dockerflow/${project}:${currentBuild.displayName}-linux-arm --os=linux --arch=arm --variant=v7"
+  
+    // Manifest push dockerflow/${project}:${currentBuild.displayName}-linux-arm
+    sh "docker manifest push dockerflow/${project}:${currentBuild.displayName}-linux-arm"
+  
     dockerLogout()
 }

--- a/vars/dfRelease2.groovy
+++ b/vars/dfRelease2.groovy
@@ -16,27 +16,48 @@ def call(String project, gox = false) {
     
     // Push image for docs
     sh "docker image push dockerflow/${project}-docs:${currentBuild.displayName}"
-      
-    /** Manifest Create Version **/
+  
+
+    // Manifest Create ${project}:${currentBuild.displayName}-linux-amd64
+    sh """docker manifest create dockerflow/${project}:${currentBuild.displayName}-linux-amd64 \
+        dockerflow/${project}:${currentBuild.displayName}-linux-amd64"""
+  
+    // Manifest Push ${project}:${currentBuild.displayName}-linux-amd64
+    sh "docker manifest push dockerflow/${project}:${currentBuild.displayName}-linux-amd64"
+  
+  
+    // Manifest Create and Push dockerflow/${project}:${currentBuild.displayName}-linux-arm
+    sh """docker manifest create dockerflow/${project}:${currentBuild.displayName}-linux-arm \
+        dockerflow/${project}:${currentBuild.displayName}-linux-arm"""
+    
+    // Manifest Annotate dockerflow/${project}:${currentBuild.displayName}-linux-arm
+    sh "docker manifest annotate dockerflow/${project}:${currentBuild.displayName}-linux-arm dockerflow/${project}:${currentBuild.displayName}-linux-arm --os=linux --arch=arm --variant=v7"
+  
+    // Manifest push dockerflow/${project}:${currentBuild.displayName}-linux-arm
+    sh "docker manifest push dockerflow/${project}:${currentBuild.displayName}-linux-arm"
+  
+  
+    // Manifest Create dockerflow/${project}:${currentBuild.displayName}
     sh """docker manifest create dockerflow/${project}:${currentBuild.displayName} \
         dockerflow/${project}:${currentBuild.displayName}-linux-amd64 \
         dockerflow/${project}:${currentBuild.displayName}-linux-arm"""
-
-    // Manifest Annotate Version
+  
+    // Manifest Annotate dockerflow/${project}:${currentBuild.displayName}
     sh "docker manifest annotate dockerflow/${project}:${currentBuild.displayName} dockerflow/${project}:${currentBuild.displayName}-linux-arm --os=linux --arch=arm --variant=v7"
   
-    // Manifest Push Version
+    // Manifest Push dockerflow/${project}:${currentBuild.displayName}
     sh "docker manifest push dockerflow/${project}:${currentBuild.displayName}"  
     
-    /** Manifest Create LATEST **/
+  
+    // Manifest Create dockerflow/${project}:latest
     sh """docker manifest create dockerflow/${project}:latest \
         dockerflow/${project}:${currentBuild.displayName}-linux-amd64 \
         dockerflow/${project}:${currentBuild.displayName}-linux-arm"""
 
-    // Manifest Annotate LATEST
+    // Manifest Annotate dockerflow/${project}:latest
     sh "docker manifest annotate dockerflow/${project}:latest dockerflow/${project}:${currentBuild.displayName}-linux-arm --os=linux --arch=arm --variant=v7"
   
-    // Manifest Push LATEST
+    // Manifest Push dockerflow/${project}:latest
     sh "docker manifest push dockerflow/${project}:latest"
 
     dockerLogout()


### PR DESCRIPTION
added individual manifest lists for both linux-amd64 and linux-arm
This fixes [docker-flow/docker-flow-proxy#18](https://github.com/docker-flow/docker-flow-proxy/issues/18) "Wrong pull when using tag 18.05.08-45-linux-arm".